### PR TITLE
add code coverage reporting to existing apexTest command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ForceCode",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "publisher": "JohnAaronNelson",
   "description": "Visual Studio Code extension for Salesforce (SFDC) development",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ForceCode",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "publisher": "JohnAaronNelson",
   "description": "Visual Studio Code extension for Salesforce (SFDC) development",
   "author": {

--- a/src/commands/apexTest.ts
+++ b/src/commands/apexTest.ts
@@ -78,7 +78,7 @@ export default function apexTest(document: vscode.TextDocument, context: vscode.
                         uncoveredLines = coverage.numLocationsNotCovered,
                         coveredLines = linesOfCode - uncoveredLines,
                         percentageCovered = Math.round((coveredLines / linesOfCode) * 100),
-                        coverageMessage:  string = `${percentageCovered}% ${coverage.name} ${coveredLines} of ${linesOfCode} covered `;
+                        coverageMessage:  string = `${percentageCovered}% ${coverage.name} ${coveredLines} of ${linesOfCode} covered \n`;
                     
                     if(coverage.numLocationsNotCovered > 0){
                         coverage.locationsNotCovered.forEach(function(uncovered){

--- a/src/commands/apexTest.ts
+++ b/src/commands/apexTest.ts
@@ -41,7 +41,7 @@ export default function apexTest(document: vscode.TextDocument, context: vscode.
                 return method.name;
             });
         }else{
-            error.outputError({ message: 'no symbol table'  }, vscode.window.forceCode.outputChannel);
+            error.outputError({ message: 'no symbol table' }, vscode.window.forceCode.outputChannel);
         }
     }
 

--- a/src/commands/apexTest.ts
+++ b/src/commands/apexTest.ts
@@ -41,7 +41,7 @@ export default function apexTest(document: vscode.TextDocument, context: vscode.
                 return method.name;
             });
         }else{
-            error.outputError({ message: 'no symbol table' }, vscode.window.forceCode.outputChannel);
+            error.outputError({ message: 'no symbol table'  }, vscode.window.forceCode.outputChannel);
         }
     }
 
@@ -71,6 +71,32 @@ export default function apexTest(document: vscode.TextDocument, context: vscode.
                 var successMessage: string = 'SUCCESS: ' + success.name + ':' + success.methodName + ' - in ' + success.time + 'ms';
                 vscode.window.forceCode.outputChannel.appendLine(successMessage);
             });
+
+            if (res.codeCoverage.length > 0){
+                res.codeCoverage.forEach(function(coverage ){
+                    var linesOfCode = coverage.numLocations,
+                        uncoveredLines = coverage.numLocationsNotCovered,
+                        coveredLines = linesOfCode - uncoveredLines,
+                        percentageCovered = Math.round((coveredLines / linesOfCode) * 100),
+                        coverageMessage:  string = `Class: ${percentageCovered}% ${coverage.name} ${coveredLines} of ${linesOfCode} covered `;
+                    
+                    if(coverage.numLocationsNotCovered > 0){
+
+                    }
+                    
+                    vscode.window.forceCode.outputChannel.appendLine(coverageMessage);
+                })
+                
+            }
+
+            if (res.codeCoverageWarnings.length > 0){
+                res.codeCoverageWarnings.forEach(function(warning ){
+                    var warningMessage:  string = 'CODE COVERAGE WARNING: ' + warning.message ;
+                    vscode.window.forceCode.outputChannel.appendLine(warningMessage);
+                })
+                
+            }
+
             vscode.window.forceCode.outputChannel.show();
             return res;
         });

--- a/src/commands/apexTest.ts
+++ b/src/commands/apexTest.ts
@@ -78,10 +78,12 @@ export default function apexTest(document: vscode.TextDocument, context: vscode.
                         uncoveredLines = coverage.numLocationsNotCovered,
                         coveredLines = linesOfCode - uncoveredLines,
                         percentageCovered = Math.round((coveredLines / linesOfCode) * 100),
-                        coverageMessage:  string = `Class: ${percentageCovered}% ${coverage.name} ${coveredLines} of ${linesOfCode} covered `;
+                        coverageMessage:  string = `${percentageCovered}% ${coverage.name} ${coveredLines} of ${linesOfCode} covered `;
                     
                     if(coverage.numLocationsNotCovered > 0){
-
+                        coverage.locationsNotCovered.forEach(function(uncovered){
+                            coverageMessage = coverageMessage + `line ${uncovered.line} uncovered\n`;
+                        });
                     }
                     
                     vscode.window.forceCode.outputChannel.appendLine(coverageMessage);
@@ -91,10 +93,12 @@ export default function apexTest(document: vscode.TextDocument, context: vscode.
 
             if (res.codeCoverageWarnings.length > 0){
                 res.codeCoverageWarnings.forEach(function(warning ){
-                    var warningMessage:  string = 'CODE COVERAGE WARNING: ' + warning.message ;
+                    var warningMessage:  string = `CODE COVERAGE WARNING: ` + warning.message ;
                     vscode.window.forceCode.outputChannel.appendLine(warningMessage);
                 })
                 
+            }else{
+                vscode.window.forceCode.outputChannel.appendLine('Aggregate coverage for classes in this test run is over 75%');
             }
 
             vscode.window.forceCode.outputChannel.show();


### PR DESCRIPTION
@celador this is just me getting my feet wet with apex testing in order to work on the "run all tests" feature.   This adds code coverage reporting for everything run by a single apex test class, so it does have usefulness already.

Next steps will be:

- figure out how to run all test (should be easy enough)
- figure out how best to visually display code coverage data (bit trickier)