### PR TITLE
Support deploying to sandbox environments via config file (Fix #86)

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -33,7 +33,7 @@ export default function deploy(context: vscode.ExtensionContext) {
     var deployOptions: any = {
         username: vscode.window.forceCode.config.username,
         password: vscode.window.forceCode.config.password,
-        loginUrl: 'https://login.salesforce.com',
+        loginUrl: vscode.window.forceCode.config.url || 'https://login.salesforce.com',
         checkOnly: true,
         testLevel: 'RunLocalTests',
         verbose: false,


### PR DESCRIPTION
This is untested but I believe would solve the issue from #86. Currently, the deploy command is assuming a login url of `https://login.salesforce.com`, where, for Sandbox environments, it should be `https://test.salesforce.com`.

The issue is also resolved by adding `"loginUrl": "https://test.salesforce.com"` directly to the `deployOptions` object in the force.json config file, however, this should prevent to need for that.