### PR TITLE
Add analytics for usage and error message tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -149,6 +149,12 @@
         "@types/node": "*"
       }
     },
+    "@types/universal-analytics": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@types/universal-analytics/-/universal-analytics-0.4.2.tgz",
+      "integrity": "sha512-ndv0aYA5tNPdl4KYUperlswuiSj49+o7Pwx8hrCiE9x2oeiMrn7A2jXFDdTLFIymiYZImDX02ycq0i6uQ3TL0A==",
+      "dev": true
+    },
     "@types/xml2js": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.3.tgz",
@@ -4489,6 +4495,154 @@
       "requires": {
         "json-stable-stringify": "^1.0.0",
         "through2-filter": "^2.0.0"
+      }
+    },
+    "universal-analytics": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.4.17.tgz",
+      "integrity": "sha512-N2JFymxv4q2N5Wmftc5JCcM5t1tp+sc1kqeDRhDL4XLY5X6PBZ0kav2wvVUZJJMvmSq3WXrmzDu062p+cSFYfQ==",
+      "requires": {
+        "debug": "^3.0.0",
+        "request": "2.86.0",
+        "uuid": "^3.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "boom": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+          "requires": {
+            "hoek": "4.x.x"
+          }
+        },
+        "cryptiles": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+          "requires": {
+            "boom": "5.x.x"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+              "requires": {
+                "hoek": "4.x.x"
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
+          },
+          "dependencies": {
+            "combined-stream": {
+              "version": "1.0.6",
+              "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+              "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+              "requires": {
+                "delayed-stream": "~1.0.0"
+              }
+            }
+          }
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+          "requires": {
+            "boom": "4.x.x",
+            "cryptiles": "3.x.x",
+            "hoek": "4.x.x",
+            "sntp": "2.x.x"
+          }
+        },
+        "hoek": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "request": {
+          "version": "2.86.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.86.0.tgz",
+          "integrity": "sha512-BQZih67o9r+Ys94tcIW4S7Uu8pthjrQVxhsZ/weOwHbDfACxvIyvnAbzFQxjy1jMtvFSzv5zf4my6cZsJBbVzw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "sntp": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+          "requires": {
+            "hoek": "4.x.x"
+          }
+        }
       }
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -411,6 +411,8 @@
     "os": "0.1.1",
     "request-light": "0.2.4",
     "salesforce-alm": "43.12.0",
+    "universal-analytics": "0.4.17",
+    "uuid": "3.3.2",
     "vscode": "1.1.21",
     "xml2js": "0.4.19"
   },
@@ -422,6 +424,7 @@
     "@types/node-fetch": "2.1.2",
     "@types/mocha": "5.2.5",
     "@types/node": "10.11.6",
+    "@types/universal-analytics": "0.4.2",
     "@types/xml2js": "0.4.3",
     "mocha": "5.2.0",
     "rimraf": "2.6.2",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ export function activate(context: vscode.ExtensionContext): any {
     });
 
     vscode.window.forceCode = ForceService.getInstance();
+    vscode.window.forceCode.storageRoot = context.storagePath;
 
     context.subscriptions.push(vscode.window.registerTreeDataProvider('ForceCode.switchUserProvider', fcConnection));
     context.subscriptions.push(vscode.window.registerTreeDataProvider('ForceCode.treeDataProvider', commandViewService));

--- a/src/forceCode.d.ts
+++ b/src/forceCode.d.ts
@@ -156,6 +156,7 @@ export interface IForceService {
     config?: Config;
     projectRoot: string;
     workspaceRoot: string;
+    storageRoot: string;
     describe: IMetadataDescribe;
     declarations?: IDeclarations;
     containerId?: string;

--- a/src/forceCode.d.ts
+++ b/src/forceCode.d.ts
@@ -166,6 +166,7 @@ export interface IForceService {
     outputChannel: vscode.OutputChannel;
     statusBarItem: vscode.StatusBarItem;
     fcDiagnosticCollection: vscode.DiagnosticCollection;
+    uuid: string;
     connect(): Promise<IForceService>;
     newContainer(force: Boolean): Promise<IForceService>;
     showStatus(message: string): void;

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -10,6 +10,7 @@ interface Constants {
     LOG_TYPE: string;
     API_VERSION: string;
     MAX_TIME_BETWEEN_FILE_CHANGES: number;
+    GA_TRACKING_ID: string;
 }
 const apexFilter: vscode.DocumentFilter[] = [
     {
@@ -31,5 +32,6 @@ const constants: Constants = {
     LOG_TYPE: 'DEVELOPER_LOG',
     API_VERSION: '43.0',
     MAX_TIME_BETWEEN_FILE_CHANGES: 10000,
+    GA_TRACKING_ID: 'UA-127320954-1'
 };
 export default constants;

--- a/src/services/configuration.ts
+++ b/src/services/configuration.ts
@@ -48,7 +48,9 @@ export default function getSetConfig(service?: forceCode.IForceService): Promise
 	const projPath = vscode.window.forceCode.workspaceRoot;
 	var lastUsername: string = '';
 	if(fs.existsSync(path.join(projPath, 'force.json'))) {
-		lastUsername = fs.readJsonSync(path.join(projPath, 'force.json')).lastUsername;
+		var forceFile = fs.readJsonSync(path.join(projPath, 'force.json'));
+		lastUsername = forceFile.lastUsername;
+		vscode.window.forceCode.uuid = forceFile.uuid;
 	}
 	
 	self.config = readConfigFile(lastUsername);

--- a/src/services/configuration.ts
+++ b/src/services/configuration.ts
@@ -46,14 +46,16 @@ export default function getSetConfig(service?: forceCode.IForceService): Promise
 		throw new Error('Open a Folder with VSCode before trying to login to ForceCode');
 	}
 	const projPath = vscode.window.forceCode.workspaceRoot;
-	var lastUsername: string = '';
+	var lastUsername: string;
 	if(fs.existsSync(path.join(projPath, 'force.json'))) {
 		var forceFile = fs.readJsonSync(path.join(projPath, 'force.json'));
 		lastUsername = forceFile.lastUsername;
-		vscode.window.forceCode.uuid = forceFile.uuid;
 	}
-	
 	self.config = readConfigFile(lastUsername);
+
+	if(fs.existsSync(vscode.window.forceCode.storageRoot)) {
+		vscode.window.forceCode.uuid = fs.readJsonSync(path.join(vscode.window.forceCode.storageRoot, 'analytics.json')).uuid;
+	}
 
 	self.projectRoot = path.join(projPath, self.config.src);
 	if (!fs.existsSync(self.projectRoot)) {
@@ -81,11 +83,13 @@ export function saveConfigFile(userName) {
 }
 
 export function readConfigFile(userName): Config {
-	const configPath: string = path.join(vscode.window.forceCode.workspaceRoot, '.forceCode', 
-		userName, 'settings.json');
 	var config: Config = {}
-	if(fs.existsSync(configPath)) {
-		config = fs.readJsonSync(configPath);
+	if(userName) {
+		const configPath: string = path.join(vscode.window.forceCode.workspaceRoot, '.forceCode', 
+			userName, 'settings.json');
+		if(fs.existsSync(configPath)) {
+			config = fs.readJsonSync(configPath);
+		}
 	}
 	return deepmerge(defautlOptions, config);
 }

--- a/src/services/fcAnalytics.ts
+++ b/src/services/fcAnalytics.ts
@@ -7,7 +7,7 @@ const pjson = require('./../../../package.json');
 /*
  * This will send tracking info to GA
  *  Each time it will send the FC version + category param as the category, the OS as the event action,
- *      the message param as the event label, and the ForceCode version as the value (integer).
+ *      and the message param as the event label.
  * 
  * This will be used to track errors and how much the extension is used.
  */

--- a/src/services/fcAnalytics.ts
+++ b/src/services/fcAnalytics.ts
@@ -6,7 +6,7 @@ const pjson = require('./../../../package.json');
 
 /*
  * This will send tracking info to GA
- *  Each time it will send the category param as the category, the OS as the event action,
+ *  Each time it will send the FC version + category param as the category, the OS as the event action,
  *      the message param as the event label, and the ForceCode version as the value (integer).
  * 
  * This will be used to track errors and how much the extension is used.
@@ -16,10 +16,9 @@ export function trackEvent(category: string, message: string): Promise<any> {
         // check if the user has opted in to tracking
         if(optIn()) {
             const params = {
-                ec: category,
+                ec: pjson.version + ' - ' + category,
                 ea: operatingSystem.getOS(),
                 el: message,
-                ev: Number.parseInt(pjson.version.split('.').join('')),
               }
             const analytics: Visitor = new Visitor(constants.GA_TRACKING_ID, vscode.window.forceCode.uuid);
             analytics.event(params, (response) => {
@@ -36,5 +35,7 @@ export function trackEvent(category: string, message: string): Promise<any> {
 }
 
 function optIn(): boolean {
-    return vscode.window.forceCode.uuid !== 'OPT-OUT';
+    const debug = vscode.env.machineId === 'someValue.machineId';
+    // turn off analytics when we are dubugging
+    return vscode.window.forceCode.uuid !== 'OPT-OUT' && !debug;
 }

--- a/src/services/fcAnalytics.ts
+++ b/src/services/fcAnalytics.ts
@@ -1,0 +1,40 @@
+import * as vscode from 'vscode';
+import constants from '../models/constants'
+import { operatingSystem } from '.';
+import { Visitor } from 'universal-analytics';
+const pjson = require('./../../../package.json');
+
+/*
+ * This will send tracking info to GA
+ *  Each time it will send the category param as the category, the OS as the event action,
+ *      the message param as the event label, and the ForceCode version as the value (integer).
+ * 
+ * This will be used to track errors and how much the extension is used.
+ */
+export function trackEvent(category: string, message: string): Promise<any> {
+    return new Promise((resolve) => {
+        // check if the user has opted in to tracking
+        if(optIn()) {
+            const params = {
+                ec: category,
+                ea: operatingSystem.getOS(),
+                el: message,
+                ev: Number.parseInt(pjson.version.split('.').join('')),
+              }
+            const analytics: Visitor = new Visitor(constants.GA_TRACKING_ID, vscode.window.forceCode.uuid);
+            analytics.event(params, (response) => {
+                if(!response) {
+                    // according to universal-analytics, no response from the callback is a success
+                    resolve(true);
+                }
+                resolve(false);
+            }).send();
+        } else {
+            resolve(false);
+        }
+    });
+}
+
+function optIn(): boolean {
+    return vscode.window.forceCode.uuid !== 'OPT-OUT';
+}

--- a/src/services/fcConnectionService.ts
+++ b/src/services/fcConnectionService.ts
@@ -241,8 +241,10 @@ export class FCConnectionService implements vscode.TreeDataProvider<FCConnection
             // this triggers a call to configuration() because the force.json file watcher, which triggers
             // refreshConnections()
             service.refreshConnsStatus();
-            fs.outputFileSync(path.join(projPath, 'force.json'), JSON.stringify({ lastUsername: orgInfo.username }, undefined, 4));
-            return Promise.resolve(hadToLogIn);
+            fs.outputFileSync(path.join(projPath, 'force.json'), 
+                JSON.stringify({ lastUsername: orgInfo.username, 
+                    uuid: vscode.window.forceCode.uuid }, undefined, 4));
+            return Promise.resolve(hadToLogIn);         
         });
         
     }

--- a/src/services/fcConnectionService.ts
+++ b/src/services/fcConnectionService.ts
@@ -242,8 +242,7 @@ export class FCConnectionService implements vscode.TreeDataProvider<FCConnection
             // refreshConnections()
             service.refreshConnsStatus();
             fs.outputFileSync(path.join(projPath, 'force.json'), 
-                JSON.stringify({ lastUsername: orgInfo.username, 
-                    uuid: vscode.window.forceCode.uuid }, undefined, 4));
+                JSON.stringify({ lastUsername: orgInfo.username }, undefined, 4));
             return Promise.resolve(hadToLogIn);         
         });
         

--- a/src/services/forceService.ts
+++ b/src/services/forceService.ts
@@ -7,6 +7,7 @@ import { FCFile } from './codeCovView';
 import { getToolingTypeFromExt } from '../parsers/getToolingType';
 import { Connection } from 'jsforce';
 import { trackEvent } from './fcAnalytics';
+import * as fs from 'fs-extra';
 const uuidv4 = require('uuid/v4');
 import klaw = require('klaw');
 
@@ -24,6 +25,7 @@ export default class ForceService implements forceCode.IForceService {
     public outputChannel: vscode.OutputChannel;
     public projectRoot: string;
     public workspaceRoot: string;
+    public storageRoot: string;
     public statusTimeout: any; 
     public uuid: string;
 
@@ -55,13 +57,15 @@ export default class ForceService implements forceCode.IForceService {
                 if(!vscode.window.forceCode.uuid) {
                     // ask the user to opt-in
                     return vscode.window.showInformationMessage(
-                        'The ForceCode Team would like to collect usage data to see how many people use our extension so we can improve your experience. Is this OK?', 'Yes', 'No')
+                        'The ForceCode Team would like to collect anonymous usage data so we can improve your experience. Is this OK?', 'Yes', 'No')
                         .then(choice => { 
                             if(choice === 'Yes') {
                                 vscode.window.forceCode.uuid = uuidv4();
                             } else {
                                 vscode.window.forceCode.uuid = 'OPT-OUT';
                             }
+                            fs.outputFileSync(path.join(vscode.window.forceCode.storageRoot, 'analytics.json'), 
+                                JSON.stringify({ uuid: vscode.window.forceCode.uuid }, undefined, 4));
                             resolve();             
                         });
                 } else {


### PR DESCRIPTION
This PR adds analytics tracking to ForceCode.

Features and notes:
-Will ask the user if they are OK with us tracking usage and error data (GDPR Compliance) and will remember the choice per project folder
-If a user opts-in, a unique UUID is assigned (Right now this is per project, this may need to change as I believe there's now a way for extensions to store data in their own folders for VSCode)
-Sends the ForceCode version number, OS, category (Currently have errors and starts of the extension), and a message (Error message or generic)
-This is currently tied to my personal GA Id, I made a new "Account" in my analytics specifically for ForceCode
-Packages will need updated via npm ci