### PR TITLE
3.9.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Step 6.  Have Fun!
 * 3.9.8
     * Add analytics features that will help make tracking down errors a little easier
     * Retrieve standard objects when retrieving all metadata
+    * Fix connection issue where users were getting 'cannot read tooling/metadata of undefined' error
     * Fix errors related to lighting components (Creating new ones and errors with 'getWSMember of undefined')
     * Fix some login related issues
     * Fix extension loading issue when moving the project directory

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The configuration file will look like the following. You can either edit this fi
 
 ```json
 {
-    "apiVersion": "43.0",
+    "apiVersion": "44.0",
     "autoCompile": true,
     "autoRefresh": true,
     "browser": "Google Chrome Canary",

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Step 6.  Have Fun!
     * Fix errors related to lighting components (Creating new ones and errors with 'getWSMember of undefined')
     * Add analytics features that will help make tracking down errors a little easier
     * Fix some login related issues
+    * Fix extension loading issue when moving the project directory
 * 3.9.7
     * Add staticResourceCacheControl setting. Now you can select if the cacheControl is public or private.
     * Fix issue with settings not loading correctly

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Step 6.  Have Fun!
     * Add analytics features that will help make tracking down errors a little easier
     * Retrieve standard objects when retrieving all metadata
     * Fix connection issue where users were getting 'cannot read tooling/metadata of undefined' error
+    * Fix 'illegal value for line' issue when trying to save scheduled class
     * Fix errors related to lighting components (Creating new ones and errors with 'getWSMember of undefined')
     * Fix some login related issues
     * Fix extension loading issue when moving the project directory

--- a/README.md
+++ b/README.md
@@ -339,6 +339,10 @@ Step 6.  Have Fun!
 
 ## Change Log
 
+* 3.9.8
+    * Fix errors related to lighting components (Creating new ones and errors with 'getWSMember of undefined')
+    * Add analytics features that will help make tracking down errors a little easier
+    * Fix some login related issues
 * 3.9.7
     * Add staticResourceCacheControl setting. Now you can select if the cacheControl is public or private.
     * Fix issue with settings not loading correctly

--- a/README.md
+++ b/README.md
@@ -340,8 +340,9 @@ Step 6.  Have Fun!
 ## Change Log
 
 * 3.9.8
-    * Fix errors related to lighting components (Creating new ones and errors with 'getWSMember of undefined')
     * Add analytics features that will help make tracking down errors a little easier
+    * Retrieve standard objects when retrieving all metadata
+    * Fix errors related to lighting components (Creating new ones and errors with 'getWSMember of undefined')
     * Fix some login related issues
     * Fix extension loading issue when moving the project directory
 * 3.9.7

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ There's no complicated setup process or project configurations, no external apps
 
 ## Slack
 
-ForceCode now has a Slack channel. Click [here](https://join.slack.com/t/forcecodeworkspace/shared_invite/enQtNDUxNzc3MzA1NDE0LTRiZmQ0MjdmMjQ0ZmQ0NjM3OTI1MGNkYmY4YjdiNTU3MWEzNGZlZGJjYjIxODA2NTA0YzkwMzhmMGNmZTIzMDc) to join us! 
+ForceCode now has a Slack channel! Click [here](https://join.slack.com/t/forcecodeworkspace/shared_invite/enQtNDUxNzc3MzA1NDE0LTRiZmQ0MjdmMjQ0ZmQ0NjM3OTI1MGNkYmY4YjdiNTU3MWEzNGZlZGJjYjIxODA2NTA0YzkwMzhmMGNmZTIzMDc) to join us! 
 Use this to ask question and receive updates on upcoming features!
 
 ### Permissions
@@ -85,10 +85,16 @@ Please note that the following permissions are required to develop on the Force.
     * Replaces need for CumulusCI w/ Ant
     * Retrieve detailed deploy information
     * ForceCode now only deploys the files contained in your package.xml! (Yes, destructiveChanges.xml, destructiveChangesPre.xml, and destructiveChangesPost.xml files will deploy as well so be careful!!!)
-* Retrieve Package - three options
+* Retrieve Package
     * Retrieve all metadata
     * Retrieve by selecting from available Packages
-    * Retrieve by package.xml    
+    * Retrieve by package.xml   
+    * Retrieve by selecting types
+    * Retrieve all classes 
+    * Retrieve all pages
+    * Retrieve all aura definition bundles (Lightning components, events, apps, etc)
+    * Retrieve all custom objects
+    * Retrieve all standard objects
 * Bundle & Deploy Static Resources on save
     * Auto refresh the browser on save (Mac only)
     * Works great with autosave
@@ -299,6 +305,11 @@ Open the org in a browser. No more logging in!!
 
 This works just like the "Search Files" feature in the developer console.
 
+### Build package.xml file
+
+This will present to you a list of all the non-foldered types that you want to include in your package.xml. Once you choose the types, you will be asked where you want to save the file. 
+    * Reports, documents, etc are foldered and currently not supported
+
 ### Get overall org test coverage
 
 Use this option and ForceCode will create a list of all apex classes and their coverage at the time of retrieval. It will also include an estimated overall coverage percentage (This is calculated by adding up all the other data (covered lines/total lines))
@@ -340,6 +351,8 @@ Step 6.  Have Fun!
 ## Change Log
 
 * 3.9.8
+    * Add package builder menu option. Pick the types you want to be in your package then choose where to save
+    * Added option to select types in retrieve menu option
     * Add analytics features that will help make tracking down errors a little easier
     * Retrieve standard objects when retrieving all metadata
     * Fix connection issue where users were getting 'cannot read tooling/metadata of undefined' error

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "forcecode",
-  "version": "3.9.7",
+  "version": "3.9.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forcecode",
-  "version": "3.9.7",
+  "version": "3.9.8",
   "publisher": "JohnAaronNelson",
   "displayName": "ForceCode",
   "description": "Visual Studio Code extension for Salesforce (SFDC) development",

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -119,7 +119,7 @@ export default function compile(document: vscode.TextDocument): Promise<any> {
             res.records.filter(r => r.State !== 'Error').forEach(containerAsyncRequest => {
                 containerAsyncRequest.DeployDetails.componentFailures.forEach(failure => {
                     if (failure.problemType === 'Error') {
-                        failure.lineNumber = (failure.lineNumber == null || failure.lineNumber === 0 ) ? 1 : failure.lineNumber;
+                        failure.lineNumber = (failure.lineNumber == null || failure.lineNumber < 1 ) ? 1 : failure.lineNumber;
                         failure.columnNumber = failure.columnNumber == null? 0 : failure.columnNumber;
 
                         var failureRange: vscode.Range = document.lineAt(failure.lineNumber - 1).range;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -13,6 +13,7 @@ import find from './find';
 import getLog from './getLog';
 import { open, showFileOptions } from './open';
 import getOverallCoverage from './overallCoverage';
+import packageBuilder from './packageBuilder';
 import retrieve from './retrieve';
 import showMenu from './menu';
 import soql from './soql';
@@ -36,6 +37,7 @@ export {
     getLog,
     open,
     getOverallCoverage,
+    packageBuilder,
     retrieve,
     settings,
     showFileOptions,

--- a/src/commands/packageBuilder.ts
+++ b/src/commands/packageBuilder.ts
@@ -1,0 +1,74 @@
+import * as vscode from 'vscode';
+import { toArray, dxService, PXML } from '../services';
+import constants from '../models/constants';
+import * as xml2js from 'xml2js';
+import * as fs from 'fs-extra';
+
+function sortFunc(a: any, b: any): number {
+    var aStr = a.label.toUpperCase();
+    var bStr = b.label.toUpperCase();
+    return aStr.localeCompare(bStr);
+}
+
+export default function packageBuilder(buildPackage?: boolean): Promise<any> {
+    return new Promise((resolve, reject) => {
+        var options: any[] = vscode.window.forceCode.describe.metadataObjects
+            .filter(el => { return !el.inFolder }).map(r => {
+                return {
+                    label: r.xmlName,
+                    detail: r.directoryName,
+                }
+            });
+        options.sort(sortFunc);
+        let config: {} = {
+            matchOnDescription: true,
+            matchOnDetail: true,
+            placeHolder: 'Select types',
+            canPickMany: true
+        };
+        vscode.window.showQuickPick(options, config).then(types => {
+            const typesArray: any[] = toArray(types);
+            if (dxService.isEmptyUndOrNull(typesArray)) {
+                reject();
+            }
+            var mappedTypes: any[] = typesArray.map(curType => {
+                if (!curType) {
+                    reject();
+                }
+                return { name: curType.label, members: '*' }
+            });
+            if(!buildPackage) {
+                resolve(mappedTypes);
+            } else {
+                // generate the file, then ask the user where to save it
+                const builder = new xml2js.Builder();
+                var packObj: PXML = {
+                    Package: {
+                        types: mappedTypes,
+                        version: vscode.window.forceCode.config.apiVersion || constants.API_VERSION
+                    },
+                }
+                var xml: string = builder.buildObject(packObj)
+                    .replace('<Package>', '<Package xmlns="http://soap.sforce.com/2006/04/metadata">')
+                    .replace(' standalone="yes"', '');
+                const defaultURI: vscode.Uri = {
+                    scheme: 'file',
+                    path: vscode.window.forceCode.projectRoot.split('\\').join('/'),
+                    fsPath: vscode.window.forceCode.projectRoot,
+                    authority: undefined,
+                    query: undefined,
+                    fragment: undefined,
+                    with: undefined,
+                    toJSON: undefined
+                }
+                vscode.window.showSaveDialog({ filters: { 'XML': ['xml'] }, defaultUri: defaultURI }).then(uri => {
+                    if(!uri) {
+                        resolve();
+                    } else {
+                        resolve(fs.outputFileSync(uri.fsPath, xml));
+                    }
+                });
+            }
+        });
+    });
+}

--- a/src/commands/retrieve.ts
+++ b/src/commands/retrieve.ts
@@ -193,10 +193,17 @@ export default function retrieve(resource?: vscode.Uri | ToolingTypes) {
             }
 
             function all() {
-                var types: any[] = vscode.window.forceCode.describe.metadataObjects.map(r => {
-                    return { name: r.xmlName, members: '*' };
+                new SObjectDescribe().describeGlobal(SObjectCategory.STANDARD).then(objs => {
+                    objs.push('*');
+                    var types: any[] = vscode.window.forceCode.describe.metadataObjects.map(r => {
+                        if(r.xmlName === 'CustomObject') {
+                            return { name: r.xmlName, members: objs };
+                        } else {
+                            return { name: r.xmlName, members: '*' };
+                        }
+                    });
+                    retrieveComponents(resolve, { types: types });
                 });
-                retrieveComponents(resolve, { types: types });
             }
 
             function getSpecificTypeMetadata(metadataType: string) {

--- a/src/commands/retrieve.ts
+++ b/src/commands/retrieve.ts
@@ -12,6 +12,7 @@ const fetch: any = require('node-fetch');
 import * as compress from 'compressing';
 import { parseString } from 'xml2js';
 import { outputToString } from '../parsers/output';
+import { packageBuilder } from '.';
 
 export interface ToolingType {
     name: string;
@@ -80,6 +81,11 @@ export default function retrieve(resource?: vscode.Uri | ToolingTypes) {
                 label: '$(package) Retrieve by package.xml',
                 detail: `Packaged (Retrieve metadata defined in Package.xml)`,
                 description: 'packaged',
+            });
+            options.push({
+                label: '$(check) Choose types...',
+                detail: `Choose which metadata types to retrieve`,
+                description: 'user-choice',
             });
             options.push({
                 label: '$(cloud-download) Get All Files from org',
@@ -188,8 +194,16 @@ export default function retrieve(resource?: vscode.Uri | ToolingTypes) {
                 getSpecificTypeMetadata('CustomObject');
             } else if (option.description === 'standardobj') {
                 getStandardObjects();
+            } else if(option.description === 'user-choice') {
+                builder();
             } else {
                 reject();
+            }
+
+            function builder() {
+                packageBuilder().then(mappedTypes => {
+                    retrieveComponents(resolve, { types: mappedTypes });
+                }).catch(reject);
             }
 
             function all() {

--- a/src/commands/saveAura.ts
+++ b/src/commands/saveAura.ts
@@ -50,9 +50,9 @@ export function saveAura(document: vscode.TextDocument, toolingType: string, Met
                 ApiVersion: vscode.window.forceCode.config.apiVersion || constants.API_VERSION,
                 Description: name.replace('_', ' '),
             }).then(bundle => {
-                results[0] = [bundle];
+                results[0] = bundle;
                 var newWSMember: forceCode.IWorkspaceMember = {
-                    id: results[0].Id,
+                    id: results[0].Id ? results[0].Id : results[0].id,
                     name: name,
                     path: document.fileName,
                     lastModifiedDate: (new Date()).toISOString(),
@@ -89,7 +89,7 @@ export function saveAura(document: vscode.TextDocument, toolingType: string, Met
         // If the Definition doesn't exist, create it
         var def: any[] = definitions.filter(result => result.DefType === DefType);
         currentObjectDefinition = def.length > 0 ? def[0] : undefined;
-        var curFCFile: FCFile = codeCovViewService.findById(bundle[0].Id);
+        var curFCFile: FCFile = codeCovViewService.findById(bundle[0].Id ? bundle[0].Id : bundle[0].id);
         if (currentObjectDefinition !== undefined) {
             if(curFCFile ? curFCFile.compareDates(currentObjectDefinition.LastModifiedDate) : false) {
                 return updateAura(curFCFile);
@@ -106,7 +106,7 @@ export function saveAura(document: vscode.TextDocument, toolingType: string, Met
                 });
             }
         } else if (bundle[0]) {
-            return vscode.window.forceCode.conn.tooling.sobject('AuraDefinition').create({ AuraDefinitionBundleId: bundle[0].Id, DefType, Format, Source }).then(res => {
+            return vscode.window.forceCode.conn.tooling.sobject('AuraDefinition').create({ AuraDefinitionBundleId: bundle[0].Id ? bundle[0].Id : bundle[0].id, DefType, Format, Source }).then(res => {
                 var tempWSMem: forceCode.IWorkspaceMember = curFCFile.getWsMember();
                 tempWSMem.lastModifiedDate = (new Date()).toISOString();
                 tempWSMem.lastModifiedByName = '';
@@ -137,11 +137,11 @@ export function saveAura(document: vscode.TextDocument, toolingType: string, Met
         // is 'js', 'css', or 'xml'
         switch (ext) {
             case 'js':
-                return 'js';
+                return 'JS';
             case 'css':
-                return 'css';
+                return 'CSS';
             default:
-                return 'xml';
+                return 'XML';
         }
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,7 @@ export function activate(context: vscode.ExtensionContext): any {
     });
 
     vscode.window.forceCode = ForceService.getInstance();
-    vscode.window.forceCode.storageRoot = context.storagePath;
+    vscode.window.forceCode.storageRoot = context.extensionPath;
 
     context.subscriptions.push(vscode.window.registerTreeDataProvider('ForceCode.switchUserProvider', fcConnection));
     context.subscriptions.push(vscode.window.registerTreeDataProvider('ForceCode.treeDataProvider', commandViewService));

--- a/src/models/commands.ts
+++ b/src/models/commands.ts
@@ -179,13 +179,25 @@ export const fcCommands: FCCommand[] = [
             return commands.staticResource(context);
         }
     },
+    {
+        commandName: 'ForceCode.buildPackage',
+        name: 'Building package.xml',
+        hidden: false,
+        description: 'Build a package.xml file and choose where to save it.',
+        detail: 'You will be able to choose the types to include in your package.xml (Only does * for members)',
+        icon: 'jersey',
+        label: 'Build package.xml file',
+        command: function (context, selectedResource?) {
+            return commands.packageBuilder(true);
+        }
+    },
     // Retrieve Package
     {
         commandName: 'ForceCode.retrievePackage',
         name: 'Retrieving package',
         hidden: false,
         description: 'Retrieve metadata to your src directory.',
-        detail: 'You will be prompted for the package name or you can choose to retrieve by your package.xml or to retrieve all metadata',
+        detail: 'You can choose to retrieve by your package.xml, retrieve all metadata, or choose which types to retrieve.',
         icon: 'cloud-download',
         label: 'Retrieve Package/Metadata',
         command: function (context, selectedResource?) {

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -30,7 +30,7 @@ const constants: Constants = {
     OUTPUT_CHANNEL_NAME: 'ForceCode',
     DEBUG_LEVEL_NAME: 'Execute_Anonymous_Debug',
     LOG_TYPE: 'DEVELOPER_LOG',
-    API_VERSION: '43.0',
+    API_VERSION: '44.0',
     MAX_TIME_BETWEEN_FILE_CHANGES: 10000,
     GA_TRACKING_ID: 'UA-127320954-1'
 };

--- a/src/services/configuration.ts
+++ b/src/services/configuration.ts
@@ -53,7 +53,7 @@ export default function getSetConfig(service?: forceCode.IForceService): Promise
 	}
 	self.config = readConfigFile(lastUsername);
 
-	if(fs.existsSync(vscode.window.forceCode.storageRoot)) {
+	if(fs.existsSync(path.join(vscode.window.forceCode.storageRoot, 'analytics.json'))) {
 		vscode.window.forceCode.uuid = fs.readJsonSync(path.join(vscode.window.forceCode.storageRoot, 'analytics.json')).uuid;
 	}
 

--- a/src/services/dxService.ts
+++ b/src/services/dxService.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { fcConnection, FCOauth} from '.';
+import { fcConnection, FCOauth, FCConnection} from '.';
 import alm = require('salesforce-alm');
 import { outputToString } from '../parsers/output';
 
@@ -198,7 +198,8 @@ export default class DXService implements DXCommands {
     }
 
     public logout(username: string): Promise<any> {
-        if(fcConnection.isLoggedIn()) {
+        const conn: FCConnection = fcConnection.getConnByUsername(username);
+        if(conn && conn.isLoggedIn) {
             return Promise.resolve(this.runCommand('auth:logout', '--noprompt --targetusername ' + username));
         } else {
             return Promise.resolve();

--- a/src/services/fcConnectionService.ts
+++ b/src/services/fcConnectionService.ts
@@ -223,11 +223,15 @@ export class FCConnectionService implements vscode.TreeDataProvider<FCConnection
             
             const forceSfdxPath = path.join(projPath, '.forceCode', orgInfo.username, '.sfdx')
             const sfdxPath = path.join(projPath, '.sfdx')
+            var sfdxStat;
+            try {
+                sfdxStat = fs.lstatSync(sfdxPath);
+            } catch(e) {}
 
-            if (fs.existsSync(sfdxPath)) {
-                if(fs.lstatSync(sfdxPath).isSymbolicLink()) {
+            if (sfdxStat) {
+                if(sfdxStat.isSymbolicLink()) {
                     // if it exists and is a symbolic link, remove it so we can relink with the new login
-                    fs.removeSync(sfdxPath);
+                    fs.unlinkSync(sfdxPath);
                 } else {
                     // not a symbolic link, so move it because it's an SFDX proj folder
                     fs.moveSync(sfdxPath, forceSfdxPath, { overwrite: true });

--- a/src/services/fcConnectionService.ts
+++ b/src/services/fcConnectionService.ts
@@ -145,7 +145,7 @@ export class FCConnectionService implements vscode.TreeDataProvider<FCConnection
     }
 
     private setupConn(service: FCConnectionService): Promise<boolean> {
-        if (!this.isLoggedIn() || (service.currentConnection && !service.currentConnection.connection)) {
+        if (!this.isLoggedIn() || !service.currentConnection || !service.currentConnection.connection) {
             return dxService.getOrgInfo()
                 .catch(() => {
                     if (service.currentConnection) {

--- a/src/services/fcConnectionService.ts
+++ b/src/services/fcConnectionService.ts
@@ -172,6 +172,7 @@ export class FCConnectionService implements vscode.TreeDataProvider<FCConnection
 
                         return service.currentConnection.connection.identity().then(res => {
                             service.currentConnection.orgInfo.userId = res.user_id;
+                            vscode.commands.executeCommand('setContext', 'ForceCodeLoggedIn', true);
                             return Promise.resolve(false);
                         });
                     }
@@ -243,7 +244,7 @@ export class FCConnectionService implements vscode.TreeDataProvider<FCConnection
             // link to the newly logged in org's sfdx folder in .forceCode/USERNAME/.sfdx
             fs.symlinkSync(forceSfdxPath, sfdxPath, 'junction');
 
-            vscode.window.forceCode.conn = this.currentConnection.connection;
+            vscode.window.forceCode.conn = service.currentConnection.connection;
             // this triggers a call to configuration() because the force.json file watcher, which triggers
             // refreshConnections()
             service.refreshConnsStatus();

--- a/src/services/fcConnectionService.ts
+++ b/src/services/fcConnectionService.ts
@@ -7,7 +7,7 @@ import constants from '../models/constants';
 const jsforce: any = require('jsforce');
 import klaw = require('klaw');
 import { Config } from '../forceCode';
-import { saveConfigFile, readConfigFile } from './configuration';
+import { saveConfigFile, readConfigFile, defautlOptions } from './configuration';
 
 export const REFRESH_EVENT_NAME: string = 'refreshConns';
 
@@ -206,11 +206,13 @@ export class FCConnectionService implements vscode.TreeDataProvider<FCConnection
         vscode.window.forceCode.containerAsyncRequestId = undefined;
         vscode.window.forceCode.containerId = undefined;
         vscode.window.forceCode.containerMembers = [];
-        const orgInfo: FCOauth = service.currentConnection.orgInfo;
+        const conn: FCConnection = service.currentConnection;
+        const orgInfo: FCOauth = conn.orgInfo;
         const projPath: string = vscode.window.forceCode.workspaceRoot;
-        const conn: FCConnection = service.getConnByUsername(orgInfo.username);
         if(conn.config) {
             vscode.window.forceCode.config = conn.config;
+        } else {
+            vscode.window.forceCode.config = defautlOptions;
         }
         vscode.window.forceCode.config.url = orgInfo.loginUrl;
         vscode.window.forceCode.config.username = orgInfo.username;


### PR DESCRIPTION
* Add package builder menu option. Pick the types you want to be in your package then choose where to save
* Added option to select types in retrieve menu option
* Retrieve standard objects when retrieving all metadata
* Fix connection issue where users were getting 'cannot read tooling/metadata of undefined' error
* Fix 'illegal value for line' issue when trying to save scheduled class
* Fix errors related to lighting components (Creating new ones and errors with 'getWSMember of undefined')
* Fix some login related issues
* Fix extension loading issue when moving the project directory