### PR TITLE
add retrieve support for metadata where inFolder is true

### DIFF
--- a/src/commands/packageBuilder.ts
+++ b/src/commands/packageBuilder.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
-import { toArray, dxService, PXML } from '../services';
+import { toArray, dxService, PXML, PXMLMember } from '../services';
 import constants from '../models/constants';
+import { IMetadataObject } from '../forceCode';
+import { SObjectDescribe, SObjectCategory } from '../dx';
 import * as xml2js from 'xml2js';
 import * as fs from 'fs-extra';
 
@@ -10,10 +12,49 @@ function sortFunc(a: any, b: any): number {
     return aStr.localeCompare(bStr);
 }
 
+export function getToolingTypes(metadataTypes: IMetadataObject[], retrieveManaged?: boolean): Promise<any> {
+    var proms = metadataTypes.map(r => {
+        return new Promise((resolve, reject) => {
+            if(r.xmlName === 'CustomObject') {
+                new SObjectDescribe().describeGlobal(SObjectCategory.STANDARD)
+                    .then(objs => {
+                        objs.push('*');
+                        resolve({ name: r.xmlName, members: objs });
+                    })
+                    .catch(reject);
+            } else if(r.inFolder) {
+                const folderType = r.xmlName === 'EmailTemplate' ? 'EmailFolder' : `${r.xmlName}Folder`;
+                vscode.window.forceCode.conn.metadata.list([{ type: folderType }])
+                    .then((folders) => {
+                        let proms: Promise<any>[] = [];
+                        folders.forEach(f => {
+                            if(f.manageableState === 'unmanaged' || retrieveManaged) {
+                                proms.push(vscode.window.forceCode.conn.metadata.list([{ type: r.xmlName, folder: f.fullName }]));
+                            }
+                        });
+                        Promise.all(proms)
+                        .then(folderList => {
+                            const members = [].concat([...folders, ...folderList])
+                                .filter(f => f !== undefined)
+                                .map(f => f.fullName);
+                            resolve({ name: r.xmlName, members: members });
+                        })
+                        .catch(reject)
+                        
+                    })
+                    .catch(reject);
+            } else {
+                resolve({ name: r.xmlName, members: '*' });
+            }
+        });                        
+    });
+    return Promise.all(proms)
+}
+
 export default function packageBuilder(buildPackage?: boolean): Promise<any> {
     return new Promise((resolve, reject) => {
         var options: any[] = vscode.window.forceCode.describe.metadataObjects
-            .filter(el => { return !el.inFolder }).map(r => {
+            .map(r => {
                 return {
                     label: r.xmlName,
                     detail: r.directoryName,
@@ -27,48 +68,47 @@ export default function packageBuilder(buildPackage?: boolean): Promise<any> {
             canPickMany: true
         };
         vscode.window.showQuickPick(options, config).then(types => {
-            const typesArray: any[] = toArray(types);
-            if (dxService.isEmptyUndOrNull(typesArray)) {
+            const typesArray: string[] = toArray(types).map(r => r.label);
+            if(dxService.isEmptyUndOrNull(typesArray)) {
                 reject();
             }
-            var mappedTypes: any[] = typesArray.map(curType => {
-                if (!curType) {
-                    reject();
-                }
-                return { name: curType.label, members: '*' }
-            });
-            if(!buildPackage) {
-                resolve(mappedTypes);
-            } else {
-                // generate the file, then ask the user where to save it
-                const builder = new xml2js.Builder();
-                var packObj: PXML = {
-                    Package: {
-                        types: mappedTypes,
-                        version: vscode.window.forceCode.config.apiVersion || constants.API_VERSION
-                    },
-                }
-                var xml: string = builder.buildObject(packObj)
-                    .replace('<Package>', '<Package xmlns="http://soap.sforce.com/2006/04/metadata">')
-                    .replace(' standalone="yes"', '');
-                const defaultURI: vscode.Uri = {
-                    scheme: 'file',
-                    path: vscode.window.forceCode.projectRoot.split('\\').join('/'),
-                    fsPath: vscode.window.forceCode.projectRoot,
-                    authority: undefined,
-                    query: undefined,
-                    fragment: undefined,
-                    with: undefined,
-                    toJSON: undefined
-                }
-                vscode.window.showSaveDialog({ filters: { 'XML': ['xml'] }, defaultUri: defaultURI }).then(uri => {
-                    if(!uri) {
-                        resolve();
+
+            getToolingTypes(vscode.window.forceCode.describe.metadataObjects.filter(f => typesArray.includes(f.xmlName)))
+                .then(mappedTypes => {
+                    if(!buildPackage) {
+                        resolve(mappedTypes);
                     } else {
-                        resolve(fs.outputFileSync(uri.fsPath, xml));
+                        // generate the file, then ask the user where to save it
+                        const builder = new xml2js.Builder();
+                        var packObj: PXML = {
+                            Package: {
+                                types: <PXMLMember[]> mappedTypes,
+                                version: vscode.window.forceCode.config.apiVersion || constants.API_VERSION
+                            },
+                        }
+                        var xml: string = builder.buildObject(packObj)
+                            .replace('<Package>', '<Package xmlns="http://soap.sforce.com/2006/04/metadata">')
+                            .replace(' standalone="yes"', '');
+                        const defaultURI: vscode.Uri = {
+                            scheme: 'file',
+                            path: vscode.window.forceCode.projectRoot.split('\\').join('/'),
+                            fsPath: vscode.window.forceCode.projectRoot,
+                            authority: undefined,
+                            query: undefined,
+                            fragment: undefined,
+                            with: undefined,
+                            toJSON: undefined
+                        }
+                        vscode.window.showSaveDialog({ filters: { 'XML': ['xml'] }, defaultUri: defaultURI }).then(uri => {
+                            if(!uri) {
+                                resolve();
+                            } else {
+                                resolve(fs.outputFileSync(uri.fsPath, xml));
+                            }
+                        });
                     }
-                });
-            }
+                })
+                .catch(reject);            
         });
     });
 }

--- a/src/commands/retrieve.ts
+++ b/src/commands/retrieve.ts
@@ -12,6 +12,7 @@ import * as compress from 'compressing';
 import { parseString } from 'xml2js';
 import { outputToString } from '../parsers/output';
 import { packageBuilder } from '.';
+import { getToolingTypes } from './packageBuilder';
 import { XHROptions, xhr } from 'request-light';
 
 export interface ToolingType {
@@ -214,17 +215,9 @@ export default function retrieve(resource?: vscode.Uri | ToolingTypes) {
             }
 
             function all() {
-                new SObjectDescribe().describeGlobal(SObjectCategory.STANDARD).then(objs => {
-                    objs.push('*');
-                    var types: any[] = vscode.window.forceCode.describe.metadataObjects.map(r => {
-                        if(r.xmlName === 'CustomObject') {
-                            return { name: r.xmlName, members: objs };
-                        } else {
-                            return { name: r.xmlName, members: '*' };
-                        }
-                    });
-                    retrieveComponents(resolve, { types: types });
-                });
+                getToolingTypes(vscode.window.forceCode.describe.metadataObjects).then(mappedTypes => {
+                    retrieveComponents(resolve, { types: mappedTypes })
+                }).catch(reject);
             }
 
             function getSpecificTypeMetadata(metadataType: string) {

--- a/src/forceCode.d.ts
+++ b/src/forceCode.d.ts
@@ -136,7 +136,7 @@ interface IContainerMember {
     id: string;
 }
 
-interface IMetadataObject {
+export interface IMetadataObject {
     directoryName: string;
     inFolder: boolean;
     metaFile: boolean;


### PR DESCRIPTION
This allows us to retrieve certain types of metadata that have a folder structure (documents, emails, reports, dashboards)