### PR TITLE
Allow refresh of src folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2992,7 +2992,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3013,12 +3014,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3033,17 +3036,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3160,7 +3166,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3172,6 +3179,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3186,6 +3194,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3193,12 +3202,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3217,6 +3228,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3297,7 +3309,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3309,6 +3322,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3394,7 +3408,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3430,6 +3445,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3449,6 +3465,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3492,12 +3509,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/models/commands.ts
+++ b/src/models/commands.ts
@@ -359,6 +359,10 @@ export const fcCommands: FCCommand[] = [
 					var proms: Promise<PXMLMember>[] = selectedResource.map(curRes => {
 						if(curRes.fsPath.startsWith(vscode.window.forceCode.projectRoot + path.sep)) {
 							return getAnyNameFromUri(curRes);
+						} else if (curRes.fsPath.startsWith(vscode.window.forceCode.projectRoot)) {
+							var fcPath: string = path.join(vscode.window.forceCode.workspaceRoot, 'force.json');
+							var forcejson: vscode.Uri = vscode.Uri.parse(fcPath);
+							return commands.retrieve(forcejson);
 						} else {
 							reject({ message: 'Only files/folders within the current org\'s src folder (' + vscode.window.forceCode.projectRoot + ') can be retrieved/refreshed.' })
 						}
@@ -386,6 +390,7 @@ export const fcCommands: FCCommand[] = [
 			if (!vscode.window.activeTextEditor) {
 				return undefined;
 			}
+			console.log(vscode.window.activeTextEditor.document.uri);
 			return commands.retrieve(vscode.window.activeTextEditor.document.uri);
 
 			function getTTIndex(toolType: string, arr: ToolingType[]): number {

--- a/src/models/commands.ts
+++ b/src/models/commands.ts
@@ -359,7 +359,7 @@ export const fcCommands: FCCommand[] = [
 					var proms: Promise<PXMLMember>[] = selectedResource.map(curRes => {
 						if(curRes.fsPath.startsWith(vscode.window.forceCode.projectRoot + path.sep)) {
 							return getAnyNameFromUri(curRes);
-						} else if (curRes.fsPath.startsWith(vscode.window.forceCode.projectRoot)) {
+						} else if (curRes.fsPath === vscode.window.forceCode.projectRoot) {
 							var fcPath: string = path.join(vscode.window.forceCode.workspaceRoot, 'force.json');
 							var forcejson: vscode.Uri = vscode.Uri.parse(fcPath);
 							return commands.retrieve(forcejson);


### PR DESCRIPTION
Currently, if you right click on the src folder and select "ForceCode: Refresh from server", you will get a message about not being able to refresh from the src location.  
This modification will execute a "ForceCode: Refresh from server" as if executed with the force.json file selected.
