### PR TITLE
Fix for lengthy Project startup and Switch Org on large projects

### DIFF
--- a/src/services/forceService.ts
+++ b/src/services/forceService.ts
@@ -199,7 +199,11 @@ export class ForceService implements forceCode.IForceService {
     notifications.showStatus('ForceCode Ready!');
 
     // get the current org info
-    return checkForChanges().then(cleanupContainers).catch(connectionError);
+    if (getVSCodeSetting('checkForFileChanges')) {
+      return checkForChanges().then(cleanupContainers).catch(connectionError);
+    } else {
+      return cleanupContainers().catch(connectionError);
+    }
 
     // we get a nice chunk of forcecode containers after using for some time, so let's clean them on startup
     function cleanupContainers(): Promise<any> {


### PR DESCRIPTION
Fix for lengthy "Getting workspace information" on startup in large projects (30k+ src files), with "checkForFileChanges" option false.  

Testing improved project startup performance from 3 minutes 15 seconds to 1 minute 9 seconds, regardless of the size of the src folder.